### PR TITLE
Fix failing test case

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -63,7 +63,7 @@ def test_retrieve_insult_raw_json(mocker):
     assert result['args']['lang'] == 'en'
 
     # Make sure the default template was returned
-    assert result['args']['template'] == ('The Kardashians are as <adjective> as '
+    assert result['args']['template'] == ('The Johnsons are as <adjective> as '
                                           '<article target=adj1> <adjective min=1 max=3 id=adj1> '
                                           '<amount> of <adjective min=1 max=3> <animal> '
                                           '<animal_part>')


### PR DESCRIPTION
Fix for the following error:

```
=========================================================================================================== FAILURES ===========================================================================================================
________________________________________________________________________________________________ test_retrieve_insult_raw_json _________________________________________________________________________________________________

mocker = <pytest_mock.MockFixture object at 0x10f67ffd0>

    def test_retrieve_insult_raw_json(mocker):
        who = 'The Johnsons'
        plural = True
        url = 'https://insult.mattbas.org/api/insult.json/?who=The+Johnsons&plural=on'
        mocker.patch('libinsult.client.build_url', return_value=url)
        result = retrieve_insult_text_raw('json', who=who, plural=plural)
    
        # Since the insults are randomly generated strings the best
        # we can do is make sure that result is actually a dict.
        assert isinstance(result, dict)
    
        # Make sure that an insult was returned
        assert ('insult' in result and result['insult'])
    
        # Make sure that the language was as expected
        assert result['args']['lang'] == 'en'
    
        # Make sure the default template was returned
>       assert result['args']['template'] == ('The Kardashians are as <adjective> as '
                                              '<article target=adj1> <adjective min=1 max=3 id=adj1> '
                                              '<amount> of <adjective min=1 max=3> <animal> '
                                              '<animal_part>')
E       AssertionError: assert 'The Johnsons...<animal_part>' == 'The Kardashi...<animal_part>'
E         - The Johnsons are as <adjective> as <article target=adj1> <adjective min=1 max=3 id=adj1> <amount> of <adjective min=1 max=3> <animal> <animal_part>
E         ?     ^^   ---
E         + The Kardashians are as <adjective> as <article target=adj1> <adjective min=1 max=3 id=adj1> <amount> of <adjective min=1 max=3> <animal> <animal_part>
E         ?     ^^^^^^ ++

tests/test_client.py:66: AssertionError

```